### PR TITLE
Fix caveats

### DIFF
--- a/mozc-emacs-helper.rb
+++ b/mozc-emacs-helper.rb
@@ -21,9 +21,10 @@ class MozcEmacsHelper < Formula
 
   def caveats
     msg = <<-EOF.undent
-To have launchd start mozc-emacs-helper at login:
-    sudo launchctl load /Library/LaunchAgents/org.mozc.inputmethod.Japanese.Converter.plist
-    sudo launchctl load /Library/LaunchAgents/org.mozc.inputmethod.Japanese.Renderer.plist
-EOF
+    To have launchd start mozc-emacs-helper at login:
+        sudo launchctl load /Library/LaunchAgents/org.mozc.inputmethod.Japanese.Converter.plist
+        sudo launchctl load /Library/LaunchAgents/org.mozc.inputmethod.Japanese.Renderer.plist
+    Please restart your operating system.
+    EOF
   end
 end

--- a/mozc-emacs-helper.rb
+++ b/mozc-emacs-helper.rb
@@ -21,7 +21,9 @@ class MozcEmacsHelper < Formula
 
   def caveats
     msg = <<-EOF.undent
-Please restart your operating system.
+To have launchd start mozc-emacs-helper at login:
+    sudo launchctl load /Library/LaunchAgents/org.mozc.inputmethod.Japanese.Converter.plist
+    sudo launchctl load /Library/LaunchAgents/org.mozc.inputmethod.Japanese.Renderer.plist
 EOF
   end
 end


### PR DESCRIPTION
素晴らしいです！ :+1: 

`launchctl load`しないと常駐しないので、修正してみました。
(再起動だけでは常駐しない。むしろ再起動の必要はないはず。)

Emacsだけ、OSXのIMEを無効化することは出来ないですかね？
Linuxであった、`XMODIFIERS=@im=none emacs`みたいなやつ。
