### PR TITLE
mod for python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ compile and install mozc-emacs-helper to Mac.
 $ brew tap hirocaster/homebrew-mozc-emacs-helper
 $ brew install mozc-emacs-helper
 ```
+
+## debug
+```
+dev
+/usr/local/Homebrew/Library/Taps/cafenero/homebrew-mozc-emacs-helper/
+
+log
+/Users/yusuke/Library/Logs/Homebrew/mozc-emacs-helper
+```

--- a/mozc-emacs-helper.rb
+++ b/mozc-emacs-helper.rb
@@ -16,6 +16,7 @@ class MozcEmacsHelper < Formula
 
     system "pwd"
     system "cp -r /Users/yusuke/mozc ."
+    # system "git clone https://github.com/google/mozc.git -b 2018-02-26 --single-branch --recursive"
     Dir.chdir "mozc" do
       system "pwd"
       system 'cp /Users/yusuke/mozc_emacs_helper.patch .'

--- a/mozc-emacs-helper.rb
+++ b/mozc-emacs-helper.rb
@@ -6,17 +6,44 @@ class MozcEmacsHelper < Formula
   version "0.0.1"
 
   def install
-    system "svn co http://src.chromium.org/svn/trunk/tools/depot_tools"
-    system "./depot_tools/gclient config http://mozc.googlecode.com/svn/trunk/src"
-    system "./depot_tools/gclient sync"
-    system "patch src/build_mozc.py < build_mozc.py.patch"
-    system "python src/build_mozc.py gyp --noqt"
-    system "python src/build_mozc.py build -c Release src/mac/mac.gyp:GoogleJapaneseInput src/mac/mac.gyp:gen_launchd_confs src/unix/emacs/emacs.gyp:mozc_emacs_helper"
+
+    # system "svn co https://src.chromium.org/svn/trunk/tools/depot_tools"
+    # system "./depot_tools/gclient config http://mozc.googlecode.com/svn/trunk/src"
+    # system "./depot_tools/gclient sync"
+    # system "patch src/build_mozc.py < build_mozc.py.patch"
+    # system "python src/build_mozc.py gyp --noqt"
+    # system "python src/build_mozc.py build -c Release src/mac/mac.gyp:GoogleJapaneseInput src/mac/mac.gyp:gen_launchd_confs src/unix/emacs/emacs.gyp:mozc_emacs_helper"
+
+    system "pwd"
+    system "cp -r /Users/yusuke/mozc ."
+    Dir.chdir "mozc" do
+      system "pwd"
+      system 'cp /Users/yusuke/mozc_emacs_helper.patch .'
+      system "ls -l"
+      system "cat mozc_emacs_helper.patch"
+      system "patch -p1 < mozc_emacs_helper.patch"
+    end
+
+    Dir.chdir "mozc/src" do
+      system "pwd"
+      system "ls -l"
+      system "echo $0"
+      system "zsh -c 'echo $0'"
+      # system "zsh -c \"GYP_DEFINES='mac_sdk=11.3 mac_deployment_target=11.4' python2 build_mozc.py gyp --noqt --branding=GoogleJapaneseInput; python2 build_mozc.py build -c Release unix/emacs/emacs.gyp:mozc_emacs_helper\" "
+      system "GYP_DEFINES='mac_sdk=11.3 mac_deployment_target=11.4' python2 build_mozc.py gyp --noqt --branding=GoogleJapaneseInput"
+      system "zsh -c 'python2 build_mozc.py build -c Release unix/emacs/emacs.gyp:mozc_emacs_helper'"
+    end
+    # install
+
 
     bin.install 'src/out_mac/Release/mozc_emacs_helper'
-    system 'sudo cp -r src/out_mac/Release/Mozc.app /Library/Input\ Methods/'
-    system 'sudo cp src/out_mac/DerivedSources/Release/mac/org.mozc.inputmethod.Japanese.Converter.plist /Library/LaunchAgents'
-    system 'sudo cp src/out_mac/DerivedSources/Release/mac/org.mozc.inputmethod.Japanese.Renderer.plist /Library/LaunchAgents'
+
+    # system 'sudo cp -r src/out_mac/Release/Mozc.app /Library/Input\ Methods/'
+    # system 'sudo cp src/out_mac/DerivedSources/Release/mac/org.mozc.inputmethod.Japanese.Converter.plist /Library/LaunchAgents'
+    # system 'sudo cp src/out_mac/DerivedSources/Release/mac/org.mozc.inputmethod.Japanese.Renderer.plist /Library/LaunchAgents'
+    system 'pwd'
+    system 'date'
+    system "cp ./mozc/src/out_mac/Release/mozc_emacs_helper /usr/local/bin"
   end
 
   def caveats

--- a/mozc_emacs_helper.patch
+++ b/mozc_emacs_helper.patch
@@ -1,0 +1,20 @@
+diff --git a/src/mac/mac.gyp b/src/mac/mac.gyp
+index 9cf0cf4f..435f8765 100644
+--- a/src/mac/mac.gyp
++++ b/src/mac/mac.gyp
+@@ -49,6 +49,7 @@
+         '../renderer/renderer.gyp:renderer_client',
+         '../session/session_base.gyp:ime_switch_util',
+         '../testing/testing.gyp:gtest_main',
++        '../unix/emacs/emacs.gyp:mozc_emacs_helper',
+         'gen_key_mappings',
+       ],
+       'variables': {
+@@ -585,7 +586,6 @@
+             ['branding=="GoogleJapaneseInput"', {
+               'dependencies': [
+                 'DevConfirmPane',
+-                'codesign_client',
+               ],
+             }],
+           ],


### PR DESCRIPTION
テスト中

homebrewではビルド通らず
`$ brew install mozc-emacs-helper`
CLI上ではビルド通る
`$ python2 build_mozc.py build -c Release unix/emacs/emacs.gyp:mozc_emacs_helper`
